### PR TITLE
hasClients check for scroll to start animation

### DIFF
--- a/lib/providers/navigation_provider.dart
+++ b/lib/providers/navigation_provider.dart
@@ -95,7 +95,8 @@ class NavigationProvider extends ChangeNotifier {
   /// If currently displayed screen has given [ScrollController] animate it
   /// to the start of scroll view.
   void _scrollToStart() {
-    if (currentScreen.scrollController != null) {
+    if (currentScreen.scrollController != null &&
+        currentScreen.scrollController.hasClients) {
       currentScreen.scrollController.animateTo(
         0,
         duration: const Duration(seconds: 1),


### PR DESCRIPTION
When navigating to the current screen and no `ScrollController` is provided, the `_scrollToStart` method throws the following exception:

```
E/flutter (16791): [ERROR:flutter/lib/ui/ui_dart_state.cc(186)] Unhandled Exception: 'package:flutter/src/widgets/scroll_controller.dart': Failed assertion: line 152 pos 12: '_positions.isNotEmpty': ScrollController not attached to any scroll views.
E/flutter (16791): #0      _AssertionError._doThrowNew (dart:core-patch/errors_patch.dart:46:39)
E/flutter (16791): #1      _AssertionError._throwNew (dart:core-patch/errors_patch.dart:36:5)
E/flutter (16791): #2      ScrollController.animateTo
package:flutter/…/widgets/scroll_controller.dart:152
E/flutter (16791): #3      NavigationProvider._scrollToStart
package:flutter_bottom_navigation/providers/navigation_provider.dart:99
E/flutter (16791): #4      NavigationProvider.setTab
package:flutter_bottom_navigation/providers/navigation_provider.dart:88
E/flutter (16791): #5      _BottomNavigationBarState._createTiles.<anonymous closure>
package:flutter/…/material/bottom_navigation_bar.dart:974
E/flutter (16791): #6      _InkResponseState._handleTap
package:flutter/…/material/ink_well.dart:991
E/flutter (16791): #7      GestureRecognizer.invokeCallback
package:flutter/…/gestures/recognizer.dart:182
E/flutter (16791): #8      TapGestureRecognizer.handleTapUp
package:flutter/…/gestures/tap.dart:607
E/flutter (16791): #9      BaseTapGestureRecognizer._checkUp
package:flutter/…/gestures/tap.dart:296
E/flutter (16791): #10     BaseTapGestureRecognizer.acceptGesture
package:flutter/…/gestures/tap.dart:267
E/flutter (16791): #11     GestureArenaManager.sweep
package:flutter/…/gestures/arena.dart:157
E/flutter (16791): #12     GestureBinding.handleEvent
package:flutter/…/gestures/binding.dart:385
E/flutter (16791): #13     GestureBinding.dispatchEvent
package:flutter/…/gestures/binding.dart:361
E/flutter (16791): #14     RendererBinding.dispatchEvent
package:flutter/…/rendering/binding.dart:278
E/flutter (16791): #15     GestureBinding._handlePointerEventImmediately
package:flutter/…/gestures/binding.dart:316
E/flutter (16791): #16     GestureBinding.handlePointerEvent
package:flutter/…/gestures/binding.dart:280
E/flutter (16791): #17     GestureBinding._flushPointerEventQueue
package:flutter/…/gestures/binding.dart:238
E/flutter (16791): #18     GestureBinding._handlePointerDataPacket
package:flutter/…/gestures/binding.dart:221
E/flutter (16791): #19     _rootRunUnary (dart:async/zone.dart:1370:13)
E/flutter (16791): #20     _CustomZone.runUnary (dart:async/zone.dart:1265:19)
E/flutter (16791): #21     _CustomZone.runUnaryGuarded (dart:async/zone.dart:1170:7)
E/flutter (16791): #22     _invoke1 (dart:ui/hooks.dart:180:10)
E/flutter (16791): #23     PlatformDispatcher._dispatchPointerDataPacket (dart:ui/platform_dispatcher.dart:276:7)
E/flutter (16791): #24     _dispatchPointerDataPacket (dart:ui/hooks.dart:96:31)
```

Checking ["Whether any ScrollPosition objects have attached themselves to the ScrollController"](https://api.flutter.dev/flutter/widgets/ScrollController/hasClients.html) should fix it.